### PR TITLE
Update debug-win command

### DIFF
--- a/templates/empty-dust/package.json
+++ b/templates/empty-dust/package.json
@@ -22,6 +22,6 @@
 		"start": "npm run release",
 		"release": "node ./build.js release && node ./server.js release",
 		"debug": "node ./build.js & node ./server.js",
-		"debug-win": "start /B node ./build.js && start /B node ./server.js"
+		"debug-win": "powershell -Command \"Start-Process -NoNewWindow node ./build.js; Start-Process -NoNewWindow -Wait node ./server.js\""
 	}
 }

--- a/templates/empty-handlebars/package.json
+++ b/templates/empty-handlebars/package.json
@@ -22,6 +22,6 @@
 		"start": "npm run release",
 		"release": "node ./build.js release && node ./server.js release",
 		"debug": "node ./build.js & node ./server.js",
-		"debug-win": "start /B node ./build.js && start /B node ./server.js"
+		"debug-win": "powershell -Command \"Start-Process -NoNewWindow node ./build.js; Start-Process -NoNewWindow -Wait node ./server.js\""
 	}
 }

--- a/templates/empty-jade/package.json
+++ b/templates/empty-jade/package.json
@@ -22,6 +22,6 @@
 		"start": "npm run release",
 		"release": "node ./build.js release && node ./server.js release",
 		"debug": "node ./build.js & node ./server.js",
-		"debug-win": "start /B node ./build.js && start /B node ./server.js"
+		"debug-win": "powershell -Command \"Start-Process -NoNewWindow node ./build.js; Start-Process -NoNewWindow -Wait node ./server.js\""
 	}
 }

--- a/templates/example/package.json
+++ b/templates/example/package.json
@@ -22,6 +22,6 @@
 		"start": "npm run release",
 		"release": "node ./build.js release && node ./server.js release",
 		"debug": "node ./build.js & node ./server.js",
-		"debug-win": "start /B node ./build.js && start /B node ./server.js"
+		"debug-win": "powershell -Command \"Start-Process -NoNewWindow node ./build.js; Start-Process -NoNewWindow -Wait node ./server.js\""
 	}
 }


### PR DESCRIPTION
After long thoughts I've asked this question on StackOverflow and [got the answer](http://stackoverflow.com/a/30415700/2684760).

We have to use PowerShell for this functionality to work properly, but that shouldn't be a problem because today there are no up-to-date Windows systems without PowerShell.

PowerShell itself will create two child processes - one in a [job object](https://msdn.microsoft.com/en-us/library/windows/desktop/ms684161(v=vs.85).aspx) with PowerShell process itself, and second with derived IO (thanks to `-Wait` switch).

After I press Ctrl-C, the second process will be killed, and after that PowerShell process will terminate itself (because it was blocked on the killed process), and OS will terminate all processes in the same job as PowerShell (so everyone will be killed, nice).

It will close issue #5 and improve debugging experience on Windows.